### PR TITLE
Fix username mismatch issue in GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-          
+
       - name: Install Go
         uses: actions/setup-go@v2
         with:
@@ -34,7 +34,7 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: true
-          tags: ${{ github.repository }}:latest
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/${{ github.event.repository.name }}:latest
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
Correctly handles mismatch between GitHub and Docker Hub usernames.

See #3 for more details.

I will also be submitting a corresponding PR to the [tutorial documentation](https://github.com/docker/docker.github.io/blob/master/language/golang/configure-ci-cd.md).  I will update this PR when that PR is submitted.